### PR TITLE
Add boss HP% to overlay

### DIFF
--- a/src-electron/util/app-settings.ts
+++ b/src-electron/util/app-settings.ts
@@ -188,6 +188,10 @@ const defaultSettings: Settings = {
         name: "Tanked",
         enabled: false,
       },
+      bossHP: {
+        name: "Boss HP",
+        enabled: false,
+      },
     },
     tabs: {
       damage: {

--- a/src/layouts/DamageMeter.vue
+++ b/src/layouts/DamageMeter.vue
@@ -85,12 +85,13 @@
             {{ numberFormat(sessionState.damageStatistics.totalDamageTaken) }}
           </span>
           <span
+            v-if="settingsStore.settings.damageMeter.header.bossHP.enabled"
             style="margin-right: 12px"
           >
-            Boss HP
+            {{(sessionBoss && sessionBoss.name) ? sessionBoss.name : "Boss"}} HP
             {{(sessionBoss && sessionBoss.currentHp && sessionBoss.maxHp) ? (abbreviateNumber(sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp).join('') +
               ' / ' +abbreviateNumber(sessionBoss.maxHp).join('') +
-              ' (' + Math.floor(((sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp) / sessionBoss.maxHp) * 100) + '%)') : '0'}}
+              ' (' + Math.floor(((sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp) / sessionBoss.maxHp) * 100).toFixed(1) + '%)') : '0'}}
           </span>
         </div>
       </div>

--- a/src/layouts/DamageMeter.vue
+++ b/src/layouts/DamageMeter.vue
@@ -328,6 +328,24 @@ async function takeScreenshot() {
 function requestSessionRestart() {
   window.messageApi.send("window-to-main", { message: "reset-session" });
 }
+
+function getSessionBoss() {
+  if (sessionState.value.entities){
+    const entities = Object.values(sessionState.value.entities);
+    if (entities.length > 0){
+      for (const entity of (entities.sort((a, b) => b.lastUpdate - a.lastUpdate))) {
+        for (const encounter of (Object.values(encounters))) {
+          if (encounter.encounterNames.includes(entity.name)) {
+            sessionBoss.value = entity;
+            return;
+          }
+        }
+      }
+    }
+    else {sessionBoss.value = null as unknown as Entity;}
+  }
+}
+
 const sessionState: Ref<Partial<Game>> = ref({});
 const sessionDPS = ref(0);
 const sessionBoss: Ref<Partial<Entity>> = ref({});
@@ -359,21 +377,7 @@ onMounted(() => {
           (fightDuration.value / 1000),
         0
       );
-      if (sessionState.value.entities){
-        const entities = Object.values(sessionState.value.entities);
-        if (entities.length > 0)
-        {
-          for (const entity of (entities.sort((a, b) => b.lastUpdate - a.lastUpdate))) {
-            for (const encounter of (Object.values(encounters))) {
-              if (encounter.encounterNames.includes(entity.name)) {
-                sessionBoss.value = entity;
-                break;
-              }
-            }
-          }
-        }
-        else {sessionBoss.value = null as unknown as Entity;}
-      }
+      getSessionBoss();
     }
   });
 

--- a/src/layouts/DamageMeter.vue
+++ b/src/layouts/DamageMeter.vue
@@ -91,7 +91,7 @@
             {{(sessionBoss && sessionBoss.name) ? sessionBoss.name : "Boss"}} HP
             {{(sessionBoss && sessionBoss.currentHp && sessionBoss.maxHp) ? (abbreviateNumber(sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp).join('') +
               ' / ' +abbreviateNumber(sessionBoss.maxHp).join('') +
-              ' (' + Math.floor(((sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp) / sessionBoss.maxHp) * 100).toFixed(1) + '%)') : '0'}}
+              ' (' + (((sessionBoss.currentHp < 0 ? 0 : sessionBoss.currentHp) / sessionBoss.maxHp) * 100).toFixed(1) + '%)') : '0'}}
           </span>
         </div>
       </div>

--- a/src/util/number-helpers.ts
+++ b/src/util/number-helpers.ts
@@ -29,11 +29,11 @@ export function numberFormat(n: number) {
 // returns an array with 2 values based on its abbreviation
 // ex: 123456 => [123, "k"]
 export function abbreviateNumber(n: number) {
-  if (n < 1e3) return [tryParseInt(n).toFixed(1), ""];
   if (n >= 1e3 && n < 1e6) return [+(n / 1e3).toFixed(1), "k"];
   if (n >= 1e6 && n < 1e9) return [+(n / 1e6).toFixed(1), "m"];
   if (n >= 1e9 && n < 1e12) return [+(n / 1e9).toFixed(1), "b"];
   if (n >= 1e12) return [+(n / 1e12).toFixed(1), "t"];
+  else return [tryParseInt(n).toFixed(1), ""];
 }
 
 // takes milliseconds in numbers and returns string with minutes:seconds


### PR DESCRIPTION
![electron_2022-12-27_16-51-50](https://user-images.githubusercontent.com/16696564/209728025-88a52bca-a90e-4924-a43d-a69662ac63f2.png)

Adds boss current hp, max hp, and hp percentage to overlay.

Boss is determined by looking at sessionState's entities property and selecting the entity with the newest(highest) lastUpdate value and has a name that appears in encounters.js. Hence only guardians and raid boss hp would be shown.

I have tested change in guardian raids but won't be able to test in legion raids until after reset.

There are room for improvement and some bugs I saw.
1. Add new setting to toggle showing of boss hp, just like total dmg, total dps, and total tank.
2. When doing non-boss content the boss hp of last fought boss will appear. This is because sessionState's entities property will  store its entities for 10 minutes. In my opinion, sessionState should drop all entities upon zone change but I don't know a way other than changing loa-details-log-parser.
3. Boss HP will sometimes fail to load. This happens when loa-details-log-parser does not parse the name of the boss properly. I notice this very often when meter is started in middle of raid rather than before the raid starts. loa-details-log-parser would declare the name of entities to be hex values rather than their actual names. This is the same bug when player names appear as hex.