### PR TITLE
fix for meter being in minimized state but not having a button to restor

### DIFF
--- a/src/layouts/DamageMeter.vue
+++ b/src/layouts/DamageMeter.vue
@@ -490,7 +490,8 @@ onMounted(() => {
   });
 
   window.messageApi.receive("on-restore-from-taskbar", (value) => {
-    if (value) isMinimized.value = false;
+    if (settingsStore.settings.damageMeter.functionality.minimizeToTaskbar && value)
+      isMinimized.value = false;
   });
 
   setInterval(() => {


### PR DESCRIPTION
if you do not minimize to taskbar and put the meter in minimized state, but then minimize it to taskbar by other means then the window buttons, e.g. using the taskbar to do so. If you restore the window from taskbar it gets set to none minimized state to the window is not restored.