### PR TITLE
Add Missing Boss IDs & More Tray Menu Options

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -178,6 +178,38 @@ function startApplication() {
       },
     },
     {
+      label: "Reset Windows",
+      submenu: [
+        {
+          label: "Both",
+          click() {
+            damageMeterWindow?.setPosition(0, 0);
+            store.set("windows.damage_meter.X", 0);
+            store.set("windows.damage_meter.Y", 0);
+            mainWindow?.setPosition(0, 0);
+            store.set("windows.main.X", 0);
+            store.set("windows.main.Y", 0);
+          }
+        },
+        {
+          label: "Damage Meter",
+          click() {
+            damageMeterWindow?.setPosition(0, 0);
+            store.set("windows.damage_meter.X", 0);
+            store.set("windows.damage_meter.Y", 0);
+          },
+        },
+        {
+          label: "Main Window",
+          click() {
+            mainWindow?.setPosition(0, 0);
+            store.set("windows.main.X", 0);
+            store.set("windows.main.Y", 0);
+          },
+        },
+      ]
+    },
+    {
       label: "Quit",
       click() {
         app.quit();

--- a/src-electron/util/helpers.ts
+++ b/src-electron/util/helpers.ts
@@ -101,6 +101,32 @@ export const raidBosses = [
   480209, // Nightmarish Morphe
   480210, // Covetous Devourer Vykas
   480211, // Covetous Legion Commander Vykas
+  // Kakul-Saydon Legion Raid
+  480601, // Saydon
+  480611, // Kakul
+  480651, // Saydon
+  480691, // Saydon
+  480631, // Kakul-Saydon
+  480635, // Encore-Desiring Kakul-Saydon
+  // Brelshaza Legion Raid
+  480815, // Brelshaza, Monarch of Nightmares
+  480805, // Crushing Phantom Wardog
+  480874, // Molting Phantom Wardog
+  480875, // Echoing Phantom Wardog
+  480876, // Raging Phantom Wardog
+  480806, // Grieving Statue
+  480807, // Furious Statue
+  480877, // Despairing Statue
+  480878, // Eroded Statue
+  480803, // Nightmare Gehenna
+  480804, // Nightmare Helkasirs
+  480802, // Gehenna Helkasirs
+  480808, // Prokel
+  480809, // Prokel's Spiritual Echo
+  480810, // Ashtarot
+  480811, // Primal Nightmare
+  480813, // Brelshaza, Monarch of Nightmares
+  480814, // Phantom Legion Commander Brelshaza
 ];
 
 export const abyssRaids = [


### PR DESCRIPTION
Adds missing legion raid boss IDs to supported bosses list to allow automatic uploads in newer raids.

Also adds options to the tray menu that allows users to reset the position of their meter/main window instead of manually editing/deleting their config file. 

![Tray Menu Example](https://user-images.githubusercontent.com/4467272/221370525-5474fe29-cd5a-4750-a7db-a042203180d1.png)
