### PR TITLE
Add setting to toggle alwaysOnTop on or off

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -331,7 +331,7 @@ const ipcFunctions: {
     });
 
     damageMeterWindow?.setOpacity(appSettings.damageMeter.design.opacity);
-    damageMeterWindow?.setAlwaysOnTop(appSettings.damageMeter.design.alwaysOnTop);
+    damageMeterWindow?.setAlwaysOnTop(appSettings.damageMeter.design.alwaysOnTop, "normal");
   },
   "get-settings": (event) => {
     event.reply("on-settings-change", appSettings);

--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -331,6 +331,7 @@ const ipcFunctions: {
     });
 
     damageMeterWindow?.setOpacity(appSettings.damageMeter.design.opacity);
+    damageMeterWindow?.setAlwaysOnTop(appSettings.damageMeter.design.alwaysOnTop);
   },
   "get-settings": (event) => {
     event.reply("on-settings-change", appSettings);

--- a/src-electron/electron-windows/damage-meter-window.ts
+++ b/src-electron/electron-windows/damage-meter-window.ts
@@ -24,7 +24,7 @@ export function createDamageMeterWindow(
     resizable: true,
     autoHideMenuBar: true,
     fullscreenable: false,
-    alwaysOnTop: true,
+    alwaysOnTop: appSettings?.damageMeter?.design?.alwaysOnTop ?? true,
     useContentSize: true,
     webPreferences: {
       devTools: process.env.DEBUGGING,
@@ -49,7 +49,7 @@ export function createDamageMeterWindow(
       initWindow(damageMeterWindow, "damage_meter");
     });
 
-  damageMeterWindow.setAlwaysOnTop(true, "normal");
+  damageMeterWindow.setAlwaysOnTop(appSettings?.damageMeter?.design?.alwaysOnTop ?? true, "normal");
 
   // Event listeners
   liveParser.on("reset-state", (state: GameState) => {

--- a/src-electron/util/app-settings.ts
+++ b/src-electron/util/app-settings.ts
@@ -114,6 +114,7 @@ export type Settings = {
       pinUserToTop: boolean;
       transparency: boolean;
       opacity: number;
+      alwaysOnTop: boolean;
     };
     header: {
       [key: string]: {
@@ -204,6 +205,7 @@ const defaultSettings: Settings = {
       pinUserToTop: false,
       transparency: true,
       opacity: 0.9,
+      alwaysOnTop: true,
     },
     header: {
       damage: {

--- a/src/components/SettingsPage/DamageMeterPage.vue
+++ b/src/components/SettingsPage/DamageMeterPage.vue
@@ -267,6 +267,21 @@
     <q-item tag="label">
       <q-item-section side top>
         <q-checkbox
+          v-model="settingsStore.settings.damageMeter.design.alwaysOnTop"
+        />
+      </q-item-section>
+
+      <q-item-section>
+        <q-item-label>Always on top</q-item-label>
+        <q-item-label caption>
+          Keeps the damage meter above other windows.
+        </q-item-label>
+      </q-item-section>
+    </q-item>
+
+    <q-item tag="label">
+      <q-item-section side top>
+        <q-checkbox
           v-model="settingsStore.settings.damageMeter.design.pinUserToTop"
         />
       </q-item-section>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -71,6 +71,7 @@ export const useSettingsStore = defineStore("settings", {
           pinUserToTop: false,
           opacity: 0.9,
           transparency: false,
+          alwaysOnTop: true,
         },
         header: {
           damage: {


### PR DESCRIPTION
Fixes https://github.com/lost-ark-dev/loa-details/issues/20.

Add a setting that allows turning "alwaysOnTop" off for the damage meter. The default behaviour is unchanged (alwaysOnTop = true).

Wrote this quickly in GitHub UI, not sure it works.