### PR TITLE
Search improvements

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -346,7 +346,7 @@ const ipcFunctions: {
     );
   },
   "get-parsed-logs": async (event) => {
-    const parsedLogs = await getParsedLogs();
+    const parsedLogs = await getParsedLogs(event);
     await event.reply("parsed-logs-list", parsedLogs);
   },
   "get-parsed-log": async (event, arg: { message: string; value: string }) => {

--- a/src/stores/log-viewer.ts
+++ b/src/stores/log-viewer.ts
@@ -5,6 +5,15 @@ export type SessionData = {
   encounterName: string;
   durationTs: number;
   duration: string;
+  playerInfos: SessionPlayerInfo[];
+  searchWords: Set<string>;
+  image: string;
+};
+
+export type SessionPlayerInfo = {
+  name: string;
+  classid: number;
+  gearscore: number;
 };
 
 export type SessionInfo = {
@@ -26,11 +35,14 @@ export type ViewerState =
   | "viewing-log";
 type State = {
   viewerState: ViewerState;
+  loadingMessage: string;
   currentSessionName: string;
   currentEncounterName: string;
   sessions: SessionInfo[];
   computedSessions: SessionInfo[];
   encounterOptions: string[];
+  encounterOptionsSessionView: string[];
+  encounterOptionsFiltered: string[];
   encounterFilter: string[];
   logfileFilter: string[];
 };
@@ -38,22 +50,28 @@ type State = {
 export const useLogViewerStore = defineStore("log-viewer", {
   state: (): State => ({
     viewerState: "loading",
+    loadingMessage: "Parsing logs",
     currentSessionName: "",
     currentEncounterName: "",
     sessions: [],
     computedSessions: [],
     encounterOptions: [],
+    encounterOptionsSessionView: [],
+    encounterOptionsFiltered: [],
     encounterFilter: [],
     logfileFilter: [],
   }),
   actions: {
     resetState() {
       this.viewerState = "loading";
+      this.loadingMessage = "Parsing logs";
       this.currentSessionName = "";
       this.currentEncounterName = "";
       this.sessions = [];
       this.computedSessions = [];
       this.encounterOptions = [];
+      this.encounterOptionsSessionView = [];
+      this.encounterOptionsFiltered = [];
       this.encounterFilter = [];
       this.logfileFilter = [];
     },


### PR DESCRIPTION
Added the ability to search using AND combined player, class and encounter names.

For this feature I need to add information about players to the parsed session files.
The information will be pulled from the _encounter.json files into the session json files the next time the use visits the Logs tab.

For my ~17GB of parsed Logs (15532 files) this upgrade process took about 4min 30s on a built version (in debugger it took considerably longer). This time might vary a lot, depending on disk/cpu speed through.
